### PR TITLE
Fixed time_template_render benchmark failing for Django>=4.0

### DIFF
--- a/benchmarks/bench_templates.py
+++ b/benchmarks/bench_templates.py
@@ -4,6 +4,7 @@ import django
 from django import template
 from django.http import HttpRequest
 from django.shortcuts import render
+from django import VERSION
 
 try:
     os.environ["DJANGO_SETTINGS_MODULE"] = "benchmarks.settings"
@@ -43,7 +44,10 @@ class TemplateBenchmarks:
         }
 
     def time_template_render(self):
-        render(HttpRequest(), "permalink.html", self.context)
+        if VERSION >= (4,0):
+            render(HttpRequest(), "permalink.html", self.context)
+        else:
+            render(HttpRequest(), "permalink_django_lte_40.html", self.context)
 
     def time_template_render_simple(self):
         context = template.Context({"stuff": "something"})

--- a/benchmarks/templates/permalink_django_lte_40.html
+++ b/benchmarks/templates/permalink_django_lte_40.html
@@ -46,44 +46,44 @@
     {% endif %}
     <div class="clear"></div>
 
-    {% if num1 != 1 %}
+    {% ifnotequal num1 1 %}
         {% if not object3 %}
-            {% if 1 != num2 %}
+            {% ifnotequal 1 num2 %}
                 {{ num2 }}
             {% else %}
                 <p>Nothing</p>
-            {% endif %}
+            {% endifnotequal %}
         {% else %}
             {{ num1 }}
         {% endif %}
-    {% endif %}
+    {% endifnotequal %}
     <div class="clear"></div>
 
-    {% if num2 != 0 %}
+    {% ifnotequal num2 0 %}
         {% if not object3 %}
-            {% if 1 != num2 %}
+            {% ifnotequal 1 num2 %}
                 {{ num2 }}
             {% else %}
                 <p>Nothing</p>
-            {% endif %}
+            {% endifnotequal %}
         {% else %}
             {{ num1 }}
         {% endif %}
-    {% endif %}
+    {% endifnotequal %}
     <div class="clear"></div>
 
 
-    {% if num1 != 0 %}
+    {% ifnotequal num1 0 %}
         {% if not object3 %}
-            {% if 1 != num2 %}
+            {% ifnotequal 1 num2 %}
                 {{ num2 }}
             {% else %}
                 <p>Nothing</p>
-            {% endif %}
+            {% endifnotequal %}
         {% else %}
             {{ num1 }}
         {% endif %}
-    {% endif %}
+    {% endifnotequal %}
     <div class="clear"></div>
 
     {% include "for_loop.html" %}


### PR DESCRIPTION
The template tags {% ifequal %} and {% ifnotequal %} have been deprecated in Django 4.0, so I modified templates/permalink.html  and replaced {% ifnotequal val1 val2 %} with {% if val1 != val2 %}. I also created a new file templates/permalink_django_lte_40.html that uses {% ifnotequal %}