### PR TITLE
Benchmark workflow modified to commit results and publish-results workflow added

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -19,11 +19,17 @@ jobs:
       - name: Run Benchmarks
         run: |-
           asv machine --machine ubuntu-22.04 --yes
-          asv run --skip-existing
+          asv run --skip-existing --strict
       - name: Commit results
+        if: github.event_name != 'pull_request'
         uses: EndBug/add-and-commit@v9
         with:
           author_name: Github actions bot
           message: 'Results for ubuntu-22.04 added [skip ci].'
           pull: '--rebase --autostash'
           add: '-f results/*'
+
+  call_publish_results_workflow:
+      needs: run_benchmarks
+      if: github.event_name != 'pull_request'
+      uses: smithdc1/django-asv/.github/workflows/publish-results.yml@main

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -5,21 +5,25 @@ on:
   push:
     branches:
       - "main"
+  schedule:
+    - cron: '0 0 * * *'
 
 jobs:
-
   run_benchmarks:
-    runs-on: ubuntu-latest
+    runs-on: 'ubuntu-22.04'
     steps:
       - name: checkout
         uses: actions/checkout@v3
-      - name: Install python
-        uses: actions/setup-python@v3
-        with:
-          python-version: '3.10'
       - name: Install Requirements
         run: pip install -r requirements.txt
       - name: Run Benchmarks
         run: |-
-          asv machine --yes
-          asv run
+          asv machine --machine ubuntu-22.04 --yes
+          asv run --skip-existing
+      - name: Commit results
+        uses: EndBug/add-and-commit@v9
+        with:
+          author_name: Github actions bot
+          message: 'results for ubuntu-22.04 added [skip ci]'
+          pull: '--rebase --autostash'
+          add: '-f results/*'

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -24,6 +24,6 @@ jobs:
         uses: EndBug/add-and-commit@v9
         with:
           author_name: Github actions bot
-          message: 'results for ubuntu-22.04 added [skip ci]'
+          message: 'Results for ubuntu-22.04 added [skip ci].'
           pull: '--rebase --autostash'
           add: '-f results/*'

--- a/.github/workflows/publish-results.yml
+++ b/.github/workflows/publish-results.yml
@@ -1,10 +1,6 @@
 name: Publish results
 
-on:
-  workflow_run:
-    workflows: ["Benchmark"]
-    types:
-      - completed
+on: workflow_call
 
 jobs:
   publish_results:

--- a/.github/workflows/publish-results.yml
+++ b/.github/workflows/publish-results.yml
@@ -1,0 +1,25 @@
+name: Publish results
+
+on:
+  workflow_run:
+    workflows: ["Benchmark"]
+    types:
+      - completed
+
+jobs:
+  publish_results:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install Requirements
+        run: pip install -r requirements.txt
+      - name: Git config
+        run: |
+          git config --global user.name "gh-pages bot"
+          git config --global user.email "gh-pages-bot@benchmarks.com"
+      - name: Fetch changes in gh-pages branch
+        run: git fetch origin gh-pages:gh-pages
+      - name: Publish results
+        run: |
+          asv gh-pages

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -4,6 +4,7 @@
     "project_url": "https://www.djangoproject.com/",
     "repo": "https://github.com/django/django.git",
     "branches": ["main"],
-    "environment_type": "virtualenv",
-    "show_commit_url": "http://github.com/django/django/commit/"
+    "environment_type": "conda",
+    "show_commit_url": "http://github.com/django/django/commit/",
+    "pythons": ["3.10", "3.9", "3.8"]
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 asv
-virtualenv
 pre-commit


### PR DESCRIPTION
- publish-results workflow now publishes the benchmarks results to the `gh-pages` branch
- benchmarks.yml workflow now runs the benchmarks against the last 10 commits and since `--skip-existing` option is used the exiting benchmarks won't run again