### PR TITLE
pre-commit checks ignore results folder

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,5 @@
+exclude: ^results/
+
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.3.0


### PR DESCRIPTION
The pre-commit checks sometimes modify files in the results folder which causes workflows to fail and sometimes extra space or lines are added so I have tried to exclude it in this PR.