### PR TITLE
urls.py changed to new format

### DIFF
--- a/benchmarks/url_benchmarks/url_resolve/benchmark.py
+++ b/benchmarks/url_benchmarks/url_resolve/benchmark.py
@@ -9,6 +9,6 @@ class UrlResolve:
 
     def time_resolve(self):
         for i in range(100):
-            resolve("/basic/")
-            resolve("/fallthroughview/")
-            resolve("/replace/1")
+            resolve("/url-resolve/basic/")
+            resolve("/url-resolve/fallthroughview/")
+            resolve("/url-resolve/replace/1")

--- a/benchmarks/url_benchmarks/url_resolve_flat/benchmark.py
+++ b/benchmarks/url_benchmarks/url_resolve_flat/benchmark.py
@@ -9,11 +9,11 @@ class UrlResolveFlat:
 
     def time_resolve_flat(self):
         paths = (
-            "/user/repo/feature19",
-            "/section0/feature0",
-            "/en/feature10",
-            "/ru/feature10",
-            "/missing",
+            "/url-resolve-flat/user/repo/feature19",
+            "/url-resolve-flat/section0/feature0",
+            "/url-resolve-flat/en/feature10",
+            "/url-resolve-flat/ru/feature10",
+            "/url-resolve-flat/missing",
         )
         for i in range(100):
             for path in paths:

--- a/benchmarks/url_benchmarks/url_resolve_nested/benchmark.py
+++ b/benchmarks/url_benchmarks/url_resolve_nested/benchmark.py
@@ -8,4 +8,4 @@ class UrlResolveNested:
         bench_setup()
 
     def time_resolve_nested(self):
-        resolve("/0/00/000/0000/00000/000000/0000000/00000000/leaf")
+        resolve("/url-resolve-nested/0/00/000/0000/00000/000000/0000000/00000000/leaf")

--- a/benchmarks/url_benchmarks/url_reverse/benchmark.py
+++ b/benchmarks/url_benchmarks/url_reverse/benchmark.py
@@ -8,7 +8,7 @@ class UrlReverse:
         bench_setup()
 
     def time_reverse(self):
-        reverse("basic")
-        reverse("catchall")
-        reverse("vars", args=[1])
-        reverse("vars", kwargs={"var": 1})
+        reverse("url_reverse:basic")
+        reverse("url_reverse:catchall")
+        reverse("url_reverse:vars", args=[1])
+        reverse("url_reverse:vars", kwargs={"var": 1})

--- a/benchmarks/url_benchmarks/url_reverse/urls.py
+++ b/benchmarks/url_benchmarks/url_reverse/urls.py
@@ -1,0 +1,17 @@
+from django.urls import re_path
+
+from . import views
+
+
+def generate_filler_patterns(num=1):
+    """Returns a list of url pattern inputs for garbage views"""
+    for n in range(num):
+        yield re_path(r"".join((r"^", r"x" * 3 * n, r"/$")), views.basic)
+
+
+app_name = "url_reverse"
+
+urlpatterns = list(generate_filler_patterns(10))
+urlpatterns.append(re_path(r"^basic/$", views.basic, name="basic"))
+urlpatterns.append(re_path(r"^[a-z]*/$", views.catchall, name="catchall"))
+urlpatterns.append(re_path(r"^replace/(?P<var>.*?)", views.vars, name="vars"))

--- a/benchmarks/url_benchmarks/url_reverse/views.py
+++ b/benchmarks/url_benchmarks/url_reverse/views.py
@@ -1,0 +1,13 @@
+from django.http import HttpResponse
+
+
+def basic(request):
+    return HttpResponse()
+
+
+def catchall(request):
+    return HttpResponse()
+
+
+def vars(request, var=None):
+    return HttpResponse()

--- a/benchmarks/urls.py
+++ b/benchmarks/urls.py
@@ -1,17 +1,37 @@
 from django.urls import include, path
 
-# url_resolve, url_reverse
-urlpatterns = [path("", include("benchmarks.url_benchmarks.url_resolve.urls"))]
+# url_resolve
+urlpatterns = [
+    path("url-resolve/", include("benchmarks.url_benchmarks.url_resolve.urls"))
+]
+
+# url_reverse
+urlpatterns.append(
+    path(
+        "url-reverse/",
+        include("benchmarks.url_benchmarks.url_reverse.urls", namespace="url_reverse"),
+    )
+)
 
 # url_resolve_flat
-urlpatterns.append(path("", include("benchmarks.url_benchmarks.url_resolve_flat.urls")))
+urlpatterns.append(
+    path(
+        "url-resolve-flat/", include("benchmarks.url_benchmarks.url_resolve_flat.urls")
+    )
+)
 
 # url_resolve_nested
 urlpatterns.append(
-    path("", include("benchmarks.url_benchmarks.url_resolve_nested.urls"))
+    path(
+        "url-resolve-nested/",
+        include("benchmarks.url_benchmarks.url_resolve_nested.urls"),
+    )
 )
 
 # template_render
 urlpatterns.append(
-    path("", include("benchmarks.template_benchmarks.template_render.urls"))
+    path(
+        "template-render/",
+        include("benchmarks.template_benchmarks.template_render.urls"),
+    )
 )

--- a/results/benchmarks.json
+++ b/results/benchmarks.json
@@ -704,7 +704,7 @@
         "warmup_time": -1
     },
     "url_benchmarks.url_resolve.benchmark.UrlResolve.time_resolve": {
-        "code": "class UrlResolve:\n    def time_resolve(self):\n        for i in range(100):\n            resolve(\"/basic/\")\n            resolve(\"/fallthroughview/\")\n            resolve(\"/replace/1\")\n\n    def setup(self):\n        bench_setup()",
+        "code": "class UrlResolve:\n    def time_resolve(self):\n        for i in range(100):\n            resolve(\"/url-resolve/basic/\")\n            resolve('/url-resolve/fallthroughview/')\n            resolve('/url-resolve/replace/1')\n\n    def setup(self):\n        bench_setup()",
         "min_run_count": 2,
         "name": "url_benchmarks.url_resolve.benchmark.UrlResolve.time_resolve",
         "number": 0,
@@ -716,11 +716,11 @@
         "timeout": 60.0,
         "type": "time",
         "unit": "seconds",
-        "version": "3c38439f75ae298159f3dfaaeadd49cad0e3432dfeac3c26430fc8b562538485",
+        "version": "5e37710342e4f2f3779b390ae26a8cbde3ba83e0fec85c9fe7540f3672314054",
         "warmup_time": -1
     },
     "url_benchmarks.url_resolve_flat.benchmark.UrlResolveFlat.time_resolve_flat": {
-        "code": "class UrlResolveFlat:\n    def time_resolve_flat(self):\n        paths = (\n            \"/user/repo/feature19\",\n            \"/section0/feature0\",\n            \"/en/feature10\",\n            \"/ru/feature10\",\n            \"/missing\",\n        )\n        for i in range(100):\n            for path in paths:\n                try:\n                    resolve(path)\n                except Resolver404:\n                    pass\n\n    def setup(self):\n        bench_setup()",
+        "code": "class UrlResolveFlat:\n    def time_resolve_flat(self):\n        paths = (\n            \"/url-resolve-flat/user/repo/feature19\",\n            \"/url-resolve-flat/section0/feature0\",\n            \"/url-resolve-flat/en/feature10\",\n            \"/url-resolve-flat/ru/feature10\",\n            \"/url-resolve-flat/missing\",\n        )\n        for i in range(100):\n            for path in paths:\n                try:\n                    resolve(path)\n                except Resolver404:\n                    pass\n\n    def setup(self):\n        bench_setup()",
         "min_run_count": 2,
         "name": "url_benchmarks.url_resolve_flat.benchmark.UrlResolveFlat.time_resolve_flat",
         "number": 0,
@@ -732,11 +732,11 @@
         "timeout": 60.0,
         "type": "time",
         "unit": "seconds",
-        "version": "2bcd27020d316f1f52e978b5431877bb72361cc17c635897341765131c0f3de6",
+        "version": "c0168b57a7e3f0fa4a288b1fb1f6c16f1533874de8cfbefc40148706bbe81c89",
         "warmup_time": -1
     },
     "url_benchmarks.url_resolve_nested.benchmark.UrlResolveNested.time_resolve_nested": {
-        "code": "class UrlResolveNested:\n    def time_resolve_nested(self):\n        resolve(\"/0/00/000/0000/00000/000000/0000000/00000000/leaf\")\n\n    def setup(self):\n        bench_setup()",
+        "code": "class UrlResolveNested:\n    def time_resolve_nested(self):\n        resolve(\"/url-resolve-nested/0/00/000/0000/00000/000000/0000000/00000000/leaf\")\n\n    def setup(self):\n        bench_setup()",
         "min_run_count": 2,
         "name": "url_benchmarks.url_resolve_nested.benchmark.UrlResolveNested.time_resolve_nested",
         "number": 0,
@@ -748,11 +748,11 @@
         "timeout": 60.0,
         "type": "time",
         "unit": "seconds",
-        "version": "9872f0a204c08cb8e70ebc08ef0bc38661b2b3bce3f34ebb56d51265ad7746f8",
+        "version": "e60bd3364bf7ff09976cd5f918ea39c249e38709687c7d71761fc96a597e42d2",
         "warmup_time": -1
     },
     "url_benchmarks.url_reverse.benchmark.UrlReverse.time_reverse": {
-        "code": "class UrlReverse:\n    def time_reverse(self):\n        reverse(\"basic\")\n        reverse(\"catchall\")\n        reverse(\"vars\", args=[1])\n        reverse(\"vars\", kwargs={\"var\": 1})\n\n    def setup(self):\n        bench_setup()",
+        "code": "class UrlReverse:\n    def time_reverse(self):\n        reverse(\"url_reverse:basic\")\n        reverse(\"url_reverse:catchall\")\n        reverse(\"url_reverse:vars\", args=[1])\n        reverse(\"url_reverse:vars\", kwargs={\"var\": 1})\n\n    def setup(self):\n        bench_setup()",
         "min_run_count": 2,
         "name": "url_benchmarks.url_reverse.benchmark.UrlReverse.time_reverse",
         "number": 0,
@@ -764,7 +764,7 @@
         "timeout": 60.0,
         "type": "time",
         "unit": "seconds",
-        "version": "59d150881cb4c34568a326e6b8c5e53e507ae1726e18543bfd6c114239ea2dc6",
+        "version": "36ffdb77bed577a567ba029e73d9fddbfc9c9477ae6c3af7364df1da0dfd3a2e",
         "warmup_time": -1
     },
     "version": 2


### PR DESCRIPTION
While writing new request response benchmarks I noticed that the URLs in benchmarks directories that had been added to the main urls.py file sometimes overlapped each other and while writing adding newer URLs one had to take into account the existing URLs and make sure that the new URL did not overlap with some other URL, so I have tried to add a new format for adding URLs here

- in the benchmark directory add the URLs to the urls.py file
- in the main urls.py file add the URL as
```python
urlpatterns.append("benchmark_name/", include('benchmarks.benchmark_type.benchmark_name.urls'))
```
this way new URLs can be added without worrying about the existing ones

I will update the README if this gets approved