### PR TITLE
Upgrade asv to 0.6.1.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-asv==0.6.0
+asv==0.6.1
 pre-commit


### PR DESCRIPTION
https://github.com/airspeed-velocity/asv/issues/1323

There were some warnings/errors in the workflow which are now gone after the upgrade: 
```
Couldn't load asv.plugins.mamba because
No module named 'mamba'
Couldn't load asv.plugins.virtualenv because
No module named 'packaging'
· No information stored about machine 'fv-az740-515'. I know about nothing.
  

Couldn't load asv.plugins.mamba because
No module named 'mamba'
Couldn't load asv.plugins.virtualenv because
No module named 'packaging'
```
See: https://github.com/django/django-asv/actions/runs/7135574098/job/19432587240

If we're lucky this might fix the daily run