### PR TITLE
Downgrade asv to 0.5.1.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-asv==0.6.1
+asv==0.5.1
 pre-commit


### PR DESCRIPTION
Hmmmm might be this issue: https://github.com/airspeed-velocity/asv/pull/1346

11.09 last passing one:https://github.com/django/django-asv/actions/runs/6140284017/job/16659044679
12.09 failed: https://github.com/django/django-asv/actions/runs/6153162463/job/16696578821

11th Sept asv 0.5.1 was installed and then on the 12th 0.6.1 was installed - I'm still guessing sorry 🤞 
