### PR TITLE
Upgraded pre-commit hooks and fixed all files.

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.11' 
+          python-version: '3.11'
       - name: Pull Changes
         if: github.event_name != 'pull_request'
         run: git pull origin

--- a/.github/workflows/publish-results.yml
+++ b/.github/workflows/publish-results.yml
@@ -10,7 +10,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.11' 
+          python-version: '3.11'
       - name: Install Requirements
         run: pip install -r requirements.txt
       - name: Git config

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ exclude: ^results/
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.4.0
+  rev: v4.5.0
   hooks:
   - id: check-added-large-files
   - id: check-case-conflict
@@ -13,14 +13,14 @@ repos:
   - id: end-of-file-fixer
   - id: trailing-whitespace
 - repo: https://github.com/psf/black
-  rev: 22.12.0
+  rev: 24.2.0
   hooks:
   - id: black
 - repo: https://github.com/pycqa/isort
-  rev: 5.11.4
+  rev: 5.13.2
   hooks:
   - id: isort
 - repo: https://github.com/PyCQA/flake8
-  rev: 6.0.0
+  rev: 7.0.0
   hooks:
   - id: flake8

--- a/benchmarks/form_benchmarks/form_validate/benchmark.py
+++ b/benchmarks/form_benchmarks/form_validate/benchmark.py
@@ -1,6 +1,5 @@
-from django.core.exceptions import ValidationError
-
 from django import forms
+from django.core.exceptions import ValidationError
 
 from ...utils import bench_setup
 

--- a/benchmarks/models.py
+++ b/benchmarks/models.py
@@ -1,8 +1,7 @@
 import os
 
-from django.db import models
-
 import django
+from django.db import models
 
 try:
     os.environ["DJANGO_SETTINGS_MODULE"] = "benchmarks.settings"

--- a/benchmarks/template_benchmarks/template_render/benchmark.py
+++ b/benchmarks/template_benchmarks/template_render/benchmark.py
@@ -1,7 +1,6 @@
+from django import VERSION, template
 from django.http import HttpRequest
 from django.shortcuts import render
-
-from django import VERSION, template
 
 from ...utils import bench_setup
 

--- a/benchmarks/utils.py
+++ b/benchmarks/utils.py
@@ -1,8 +1,7 @@
 import os
 
-from django.core.management import CommandError, call_command
-
 import django
+from django.core.management import CommandError, call_command
 
 
 def bench_setup(migrate=False):


### PR DESCRIPTION
Whilst committing #78, I saw pre-commit f to install isort due to the pinned version being incompatible with a more recent Poetry version: https://github.com/PyCQA/isort/issues/2077 . This PR fixes the problem by upgrading isort, along with all the other hooks.

I ran `pre-commit run --all-files` to update files for the new tool versions. The changes don’t seem to be from the new versions, but rather from unfixed files existing in the repo 🤷 