### PR TITLE
Upgrade asv to 0.6.3 and update build_command.

### DIFF
--- a/asv.conf.json
+++ b/asv.conf.json
@@ -11,5 +11,5 @@
     "environment_type": "conda",
     "conda_channels": ["conda-forge", "defaults"],
     "show_commit_url": "http://github.com/django/django/commit/",
-    "pythons": ["3.10"]
+    "pythons": ["3.10", "3.11", "3.12"]
 }

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -4,8 +4,12 @@
     "project_url": "https://www.djangoproject.com/",
     "repo": "https://github.com/django/django.git",
     "branches": ["main"],
+    "build_command": [
+        "python -m pip install build",
+        "python -m build --wheel -o {build_cache_dir} {build_dir}"
+    ],
     "environment_type": "conda",
     "conda_channels": ["conda-forge", "defaults"],
     "show_commit_url": "http://github.com/django/django/commit/",
-    "pythons": ["3.10", "3.9", "3.8"]
+    "pythons": ["3.10"]
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-asv==0.5.1
+asv==0.6.3
 pre-commit


### PR DESCRIPTION
Benchmarks started failing due after https://github.com/django/django/commit/4686541691dbe986f58ac87630c3b7a04db4ff93 the [default asv build command](https://asv.readthedocs.io/en/stable/asv.conf.json.html#build-command-install-command-uninstall-command) needs updating ([see here](https://github.com/airspeed-velocity/asv/blob/4af8c69986fc1330eb1ecefb44cd79fd70e1aa19/asv/template/asv.conf.json#L24))

The previous reasons to downgrade seem to be resolved also

- https://github.com/airspeed-velocity/asv/releases/tag/v0.6.2
- https://github.com/airspeed-velocity/asv/pull/1346