### PR TITLE
Add URL benchmarks for `path` URLs

### DIFF
--- a/benchmarks/url_benchmarks/url_resolve/benchmark.py
+++ b/benchmarks/url_benchmarks/url_resolve/benchmark.py
@@ -12,3 +12,9 @@ class UrlResolve:
             resolve("/url-resolve/basic/")
             resolve("/url-resolve/fallthroughview/")
             resolve("/url-resolve/replace/1")
+
+    def time_resolve_path(self):
+        resolve("/url-resolve/num/1/")
+
+    def time_resolve_literal_path(self):
+        resolve("/url-resolve/basic-path/")

--- a/benchmarks/url_benchmarks/url_resolve/benchmark.py
+++ b/benchmarks/url_benchmarks/url_resolve/benchmark.py
@@ -1,4 +1,4 @@
-from django.urls import resolve
+from django.urls import resolve, Resolver404
 
 from ...utils import bench_setup
 
@@ -18,3 +18,9 @@ class UrlResolve:
 
     def time_resolve_literal_path(self):
         resolve("/url-resolve/basic-path/")
+
+    def time_resolve_unknown(self):
+        try:
+            resolve("/unknown/")
+        except Resolver404:
+            pass

--- a/benchmarks/url_benchmarks/url_resolve/urls.py
+++ b/benchmarks/url_benchmarks/url_resolve/urls.py
@@ -1,4 +1,4 @@
-from django.urls import re_path
+from django.urls import path, re_path
 
 from . import views
 
@@ -13,3 +13,5 @@ urlpatterns = list(generate_filler_patterns(10))
 urlpatterns.append(re_path(r"^basic/$", views.basic, name="basic"))
 urlpatterns.append(re_path(r"^[a-z]*/$", views.catchall, name="catchall"))
 urlpatterns.append(re_path(r"^replace/(?P<var>.*?)", views.vars, name="vars"))
+urlpatterns.append(path("num/<int:var>/", views.vars, name="num"))
+urlpatterns.append(path("basic-path/", views.vars, name="basic-path"))

--- a/benchmarks/url_benchmarks/url_reverse/benchmark.py
+++ b/benchmarks/url_benchmarks/url_reverse/benchmark.py
@@ -12,3 +12,10 @@ class UrlReverse:
         reverse("url_reverse:catchall")
         reverse("url_reverse:vars", args=[1])
         reverse("url_reverse:vars", kwargs={"var": 1})
+
+    def time_reverse_path(self):
+        reverse("url_reverse:num", args=[1])
+        reverse("url_reverse:num", kwargs={"var": 1})
+
+    def time_reverse_literal_path(self):
+        reverse("url_reverse:basic-path")

--- a/benchmarks/url_benchmarks/url_reverse/urls.py
+++ b/benchmarks/url_benchmarks/url_reverse/urls.py
@@ -1,4 +1,4 @@
-from django.urls import re_path
+from django.urls import path, re_path
 
 from . import views
 
@@ -15,3 +15,5 @@ urlpatterns = list(generate_filler_patterns(10))
 urlpatterns.append(re_path(r"^basic/$", views.basic, name="basic"))
 urlpatterns.append(re_path(r"^[a-z]*/$", views.catchall, name="catchall"))
 urlpatterns.append(re_path(r"^replace/(?P<var>.*?)", views.vars, name="vars"))
+urlpatterns.append(path("num/<int:var>/", views.vars, name="num"))
+urlpatterns.append(path("basic-path/", views.vars, name="basic-path"))


### PR DESCRIPTION
It'll be helpful as time goes on to have a better understanding of `path` based URLs, not just `re_path`.

See also https://github.com/django/django/pull/18270 for some hopeful performance improvements for simple cases of `path`.

I've intentionally not modified other existing benchmarks (at least cases) to avoid 