### PR TITLE
Dropped benchmarks for Python 3.10 and 3.11 as no longer supported by Django.

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: '3.12'
       - name: Pull Changes
         if: github.event_name != 'pull_request'
         run: git pull origin

--- a/.github/workflows/publish-results.yml
+++ b/.github/workflows/publish-results.yml
@@ -10,7 +10,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: '3.12'
       - name: Install Requirements
         run: pip install -r requirements.txt
       - name: Git config

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -11,5 +11,5 @@
     "environment_type": "conda",
     "conda_channels": ["conda-forge", "defaults"],
     "show_commit_url": "http://github.com/django/django/commit/",
-    "pythons": ["3.10", "3.11", "3.12", "3.13"]
+    "pythons": ["3.12", "3.13"]
 }


### PR DESCRIPTION
The benchmarks have been failing since Python 3.10 and 3.11 were dropped last week (see https://github.com/django/django/commit/f5772de69679efb54129ac1cbca3579b512778af and https://github.com/django/django-asv/actions)