### PR TITLE
Add benchmark for Model.objects.bulk_create()

### DIFF
--- a/benchmarks/model_benchmarks/model_bulk_create/benchmark.py
+++ b/benchmarks/model_benchmarks/model_bulk_create/benchmark.py
@@ -1,0 +1,10 @@
+from ...utils import bench_setup
+from .models import Book
+
+
+class ModelCreate:
+    def setup(self):
+        bench_setup(migrate=True)
+
+    def time_model_bulk_creation(self):
+        Book.objects.bulk_create([Book(title=f"Book {i}") for i in range(1_000)])

--- a/benchmarks/model_benchmarks/model_bulk_create/models.py
+++ b/benchmarks/model_benchmarks/model_bulk_create/models.py
@@ -1,0 +1,9 @@
+from django.db import models
+
+from ...utils import bench_setup
+
+bench_setup()
+
+
+class Book(models.Model):
+    title = models.CharField(max_length=100)

--- a/benchmarks/settings.py
+++ b/benchmarks/settings.py
@@ -21,6 +21,7 @@ INSTALLED_APPS = [
     "benchmarks.query_benchmarks.query_complex_filter",
     "benchmarks.query_benchmarks.query_dates",
     "benchmarks.query_benchmarks.query_delete_related",
+    "benchmarks.model_benchmarks.model_bulk_create",
     "benchmarks.model_benchmarks.model_create",
     "benchmarks.model_benchmarks.model_save_new",
     "benchmarks.model_benchmarks.model_save_existing",


### PR DESCRIPTION
Re: https://code.djangoproject.com/ticket/36858#comment:1

This benchmark tests the very basics, using a model with just one `CharField`, like the existing `model_create` benchmark.

I don't have a working asv setup right now, so only testing on CI. (Which crashed 😢)