### PR TITLE
Ref #36912 - Added benchmarks for Q.create()

### DIFF
--- a/benchmarks/query_benchmarks/query_utils_q_create/benchmark.py
+++ b/benchmarks/query_benchmarks/query_utils_q_create/benchmark.py
@@ -1,0 +1,39 @@
+from django.db.models import Q
+
+from ...utils import bench_setup
+
+
+class QCreate:
+    def setup(self):
+        bench_setup()
+        self.children_no_args = []
+        self.children_small = [("name", "Alice"), ("age", 30)]
+        self.children_large = [(f"field_{i}", i) for i in range(20)]
+        self.children_args_only = ["some_condition"]
+        self.children_mixed = [
+            "cond1",
+            "cond2",
+            ("name", "Bob"),
+            ("active", True),
+            ("score", 99),
+        ]
+
+    def time_create_no_args(self):
+        for _ in range(100):
+            Q().create(children=self.children_no_args)
+
+    def time_create_small(self):
+        for _ in range(100):
+            Q().create(children=self.children_small)
+
+    def time_create_large(self):
+        for _ in range(100):
+            Q().create(children=self.children_large)
+
+    def time_create_args_only(self):
+        for _ in range(100):
+            Q().create(children=self.children_args_only)
+
+    def time_create_mixed(self):
+        for _ in range(100):
+            Q().create(children=self.children_mixed)

--- a/benchmarks/settings.py
+++ b/benchmarks/settings.py
@@ -54,6 +54,7 @@ INSTALLED_APPS = [
     "benchmarks.query_benchmarks.query_raw_deferred",
     "benchmarks.query_benchmarks.query_raw",
     "benchmarks.query_benchmarks.query_select_related",
+    "benchmarks.query_benchmarks.query_utils_q_create",
     "benchmarks.req_resp_benchmarks.default_middleware",
     "benchmarks.req_resp_benchmarks.http_methods",
 ]


### PR DESCRIPTION
Added benchmarks for Q.create() in benchmarks/query_benchmarks/query_utils_q_create and Q in benchmarks/query_benchmarks/query_utils_q to be used in Ticket 36912 for comparison on whether to add validation to Q.create().

The config I used to run my benchmarks:

```
{
    "version": 1,
    "project": "Django",
    "project_url": "https://www.djangoproject.com/",
    "repo": "https://github.com/amakarudze/django.git",
    "branches": ["main", "ticket_36912"],
    "build_command": [
        "python -m pip install build",
        "python -m build --wheel -o {build_cache_dir} {build_dir}"
    ],
    "environment_type": "virtualenv",
    "show_commit_url": "http://github.com/amakarudze/django/commit/"
}
```

### Results for main and ticket_36912 branches
Running 10 total benchmarks (2 commits * 1 environments * 5 benchmarks)
[ 0.00%] · For Django commit d61f33f0 <main>:
[ 0.00%] ·· Benchmarking virtualenv-py3.14
[ 5.00%] ··· Running (query_benchmarks.query_utils_q_create.benchmark.TimeQCreate.time_create_args_only--).....
[30.00%] ··· query_benchmarks.query_utils_q_create.benchmark.TimeQCreate.time_create_args_only                 104±1μs
[35.00%] ··· query_benchmarks.query_utils_q_create.benchmark.TimeQCreate.time_create_large                     104±2μs
[40.00%] ··· query_benchmarks.query_utils_q_create.benchmark.TimeQCreate.time_create_mixed                     101±1μs
[45.00%] ··· query_benchmarks.query_utils_q_create.benchmark.TimeQCreate.time_create_no_args                  99.8±2μs
[50.00%] ··· query_benchmarks.query_utils_q_create.benchmark.TimeQCreate.time_create_small                   103±0.5μs
[50.00%] · For Django commit 3126b15f <ticket_36912>:
[50.00%] ·· Building for virtualenv-py3.14.....
[50.00%] ·· Benchmarking virtualenv-py3.14
[55.00%] ··· Running (query_benchmarks.query_utils_q_create.benchmark.TimeQCreate.time_create_args_only--).....
[80.00%] ··· query_benchmarks.query_utils_q_create.benchmark.TimeQCreate.time_create_args_only                 173±2μs
[85.00%] ··· query_benchmarks.query_utils_q_create.benchmark.TimeQCreate.time_create_large                     177±3μs
[90.00%] ··· query_benchmarks.query_utils_q_create.benchmark.TimeQCreate.time_create_mixed                     172±1μs
[95.00%] ··· query_benchmarks.query_utils_q_create.benchmark.TimeQCreate.time_create_no_args                   168±4μs
[100.00%] ··· query_benchmarks.query_utils_q_create.benchmark.TimeQCreate.time_create_small                     174±1μs