### PR TITLE
Add explicit permission to benchmark.yml

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+permissions:
+  contents: write
+
 jobs:
   run_benchmarks:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Thanks for the heads up @smithdc1, this is exactly what changed after we tweaked an organization-level setting to require explicit write permissions on workflows.

This should flow through to the callable workflow that runs `asv gh-pages`.